### PR TITLE
FIXED THE FONT, and added it to the leaderboard page title

### DIFF
--- a/ProjectSourceCode/src/views/pages/leaderboard.hbs
+++ b/ProjectSourceCode/src/views/pages/leaderboard.hbs
@@ -15,8 +15,8 @@
     </div>
 
 </div> --}}
-<div class="container justify-content-center align-items-center">
-    <h1 class="py-2">Behold, the best comedians...</h1>
+<div class="container justify-content-center align-items-center mt-5">
+    <h1 class="py-2 henny-penny-regular">Behold, the best comedians...</h1>
     <div class="container border rounded justify-content-center align-items-center overflow-auto" style="height: 400px;">
         <div class="row mb-1">
             <div class="col col-6 text-start">

--- a/ProjectSourceCode/src/views/partials/head.hbs
+++ b/ProjectSourceCode/src/views/partials/head.hbs
@@ -30,7 +30,7 @@
 
   <!-- Bootstrap and custom CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-  <link rel="stylesheet" href="../../resources/css/style.css">
+  <link rel="stylesheet" href="/css/style.css">
 
 </head>
 <body class="h-100 d-flex flex-column">


### PR DESCRIPTION
Turns out CSS link became broken at some point, but now it's fixed. Use class="henny-penny-regular" to implement the font in HTML.