### PR TITLE
New icons for like and dislike buttons, and they are mutually exclusive

### DIFF
--- a/ProjectSourceCode/src/index.js
+++ b/ProjectSourceCode/src/index.js
@@ -398,12 +398,16 @@ app.post('/profile/edit', auth, async (req, res) => {
 // Once the joke creation backend is implemented, we can replace the console logs with the actual data inserts.
 app.post('/rateJoke', (req,res) => {
   const rating = req.body.data;
+  console.log(rating)
   switch (rating) {
     case "upvote":
       console.log("the joke was upvoted");
       break;
     case "downvote":
       console.log("the joke was downvoted")
+      break;
+    default:
+      console.log("broken")
       break;
   }
 });

--- a/ProjectSourceCode/src/index.js
+++ b/ProjectSourceCode/src/index.js
@@ -412,7 +412,7 @@ app.post('/rateJoke', (req,res) => {
       console.log("the joke was downvoted")
       break;
     default:
-      console.log("broken")
+      console.log("no interaction with the joke")
       break;
   }
 });

--- a/ProjectSourceCode/src/resources/css/style.css
+++ b/ProjectSourceCode/src/resources/css/style.css
@@ -90,11 +90,11 @@ input:checked + .slider:before {
   transform: translateX(26px);
 }
 
-input[type="radio"] {
+input[type="checkbox"] {
   -webkit-appearance: none;
 }
 
-input[type="radio"]:checked + label {
+input[type="checkbox"]:checked + label {
   color: red;
 }
 

--- a/ProjectSourceCode/src/resources/css/style.css
+++ b/ProjectSourceCode/src/resources/css/style.css
@@ -90,6 +90,14 @@ input:checked + .slider:before {
   transform: translateX(26px);
 }
 
+input[type="radio"] {
+  -webkit-appearance: none;
+}
+
+input[type="radio"]:checked + label {
+  color: red;
+}
+
 /* Rounded sliders */
 .slider.round {
   border-radius: 34px;

--- a/ProjectSourceCode/src/resources/js/script.js
+++ b/ProjectSourceCode/src/resources/js/script.js
@@ -49,12 +49,13 @@ console.log("script.js loaded");
 // Allows to call api routes without refreshing the page  
 document.addEventListener("submit", async (event) => {
   const e = event.target;
+  //console.log(e)
   switch (e.id) {
     case "rateJoke":
       event.preventDefault();
 
       const rateData = new FormData(event.target);
-      const rating = rateData.get('rating');
+      const rating = rateData.getAll('rate')[0];
       console.log(rating)
       await fetch('/rateJoke', {
         method: 'POST', 
@@ -119,3 +120,13 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
   }
 });
+
+function switchInteraction(option) {
+  const groupName = option.name;
+  const interactions = document.getElementsByName(groupName);
+  interactions.forEach((item) => {
+    if (item !== option) item.checked = false;
+  });
+
+  option.form.requestSubmit();
+}

--- a/ProjectSourceCode/src/resources/js/script.js
+++ b/ProjectSourceCode/src/resources/js/script.js
@@ -51,8 +51,10 @@ document.addEventListener("submit", async (event) => {
   console.log(event.target.id)
   if (event.target.id === "rateJoke") {
     event.preventDefault();
-  
-    const rating = event.submitter.value
+
+    const data = new FormData(event.target);
+    const rating = data.get('rating');
+    console.log(rating)
     const res = await fetch('/rateJoke', {
       method: 'POST', 
       headers: { 'Content-Type' : 'application/json' },

--- a/ProjectSourceCode/src/views/partials/post.hbs
+++ b/ProjectSourceCode/src/views/partials/post.hbs
@@ -20,15 +20,17 @@
                             <form action="/rateJoke" method="POST" id="rateJoke">
                                 {{!-- <button type="submit" name="rate" value="upvote" onclick="alert('You liked this post!')" style="font-size: x-large;">😂</button>
                                 <button type="submit" name="rate" value="downvote" onclick="alert('You disliked this post!')" style="font-size: x-large;">😢</button> --}}
-                        <input type="radio" id="like" name="rating" value="upvote" onchange="this.form.querySelector('#secret_submit').click()">
-                        <label for="like" style="font-size: x-large;">
-                            <i class="fa-solid fa-heart"></i>
-                        </label>
-                        <input type="radio" id="dislike" name="rating" value="downvote" onchange="this.form.querySelector('#secret_submit').click()">
-                        <label for="dislike" style="font-size: x-large;">
-                            <i class="fa-solid fa-heart-crack"></i>
-                        </label>
-                        <button id="secret_submit" type="submit" style="display: none"></button>
+                                {{!-- <input type="radio" id="like" name="rating" value="upvote" onchange="this.form.querySelector('#secret_submit').click()"> --}}
+                                <input type="checkbox" id="like" name="rate" value="upvote" onclick="switchInteraction(this)">
+                                <label for="like" style="font-size: x-large;">
+                                    <i class="fa-solid fa-heart"></i>
+                                </label>
+                                {{!-- <input type="radio" id="dislike" name="rating" value="downvote" onchange="this.form.querySelector('#secret_submit').click()"> --}}
+                                <input type="checkbox" id="dislike" name="rate" value="downvote" onclick="switchInteraction(this)">
+                                <label for="dislike" style="font-size: x-large;">
+                                    <i class="fa-solid fa-heart-crack"></i>
+                                </label>
+                                <button id="secret_submit" type="submit" style="display: none"></button>
                             </form>
                         </div>
                         <div class="col-6 d-flex justify-content-end align-items-center">

--- a/ProjectSourceCode/src/views/partials/post.hbs
+++ b/ProjectSourceCode/src/views/partials/post.hbs
@@ -16,8 +16,17 @@
                 </div>
                 <div class="card-footer bg-white">
                     <form action="/rateJoke" method="POST" id="rateJoke">
-                        <button type="submit" name="rate" value="upvote" onclick="alert('You liked this post!')" style="font-size: x-large;">😂</button>
-                        <button type="submit" name="rate" value="downvote" onclick="alert('You disliked this post!')" style="font-size: x-large;">😢</button>
+                        {{!-- <button type="submit" name="rate" value="upvote" onclick="alert('You liked this post!')" style="font-size: x-large;">😂</button>
+                        <button type="submit" name="rate" value="downvote" onclick="alert('You disliked this post!')" style="font-size: x-large;">😢</button> --}}
+                        <input type="radio" id="like" name="rating" value="upvote" onchange="this.form.querySelector('#secret_submit').click()" checked>
+                        <label for="like" style="font-size: x-large;">
+                            <i class="fa-solid fa-heart"></i>
+                        </label>
+                        <input type="radio" id="dislike" name="rating" value="downvote" onchange="this.form.querySelector('#secret_submit').click()">
+                        <label for="dislike" style="font-size: x-large;">
+                            <i class="fa-solid fa-heart-crack"></i>
+                        </label>
+                        <button id="secret_submit" type="submit" style="display: none"></button>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
The likes and dislike buttons now have icons from fontawesome. The selected icon turns red to signify that interaction is chosen. Additionally, they are mutually exclusive, so only one can be selected. Selecting the one that isn't chosen will deselect the other one. They only update for the first placeholder post in the feed, this is because the placeholders are duplicates and have the same tag id's, but this will be fixed once the feed is populated with jokes from the db.